### PR TITLE
JHE FHIR endpoint is now all caps and case-sensitive

### DIFF
--- a/jupyterhealth_client/_client.py
+++ b/jupyterhealth_client/_client.py
@@ -123,7 +123,7 @@ class JupyterHealthClient:
             url = URL(path)
         else:
             if fhir:
-                url = self._url / "fhir/r5"
+                url = self._url / "FHIR/R5"
             else:
                 url = self._url / "api/v1"
             url = url / path

--- a/jupyterhealth_client/_client.py
+++ b/jupyterhealth_client/_client.py
@@ -141,11 +141,20 @@ class JupyterHealthClient:
             # return None for empty response body
             return None
 
-    def _list_api_request(self, path: str, **kwargs) -> Generator[dict[str, Any]]:
+    def _list_api_request(
+        self, path: str, limit=None, **kwargs
+    ) -> Generator[dict[str, Any]]:
         """Get a list from an /api/v1 endpoint"""
         r: dict = self._api_request(path, **kwargs)
+        count: int = 0
         yield from r["results"]
-        # TODO: handle pagination fields
+        count += len(r["results"])
+        while r.get("next", None) and (limit is None or count < limit):
+            response = self.session.get(r["next"])
+            response.raise_for_status()
+            r = response.json()
+            yield from r["results"]
+            count += len(r["results"])
 
     @staticmethod
     def _get_link(bundle, rel):

--- a/tests/responses.yaml
+++ b/tests/responses.yaml
@@ -206,7 +206,7 @@
           name: Some Device
           supportedScopes: []
           type: personal_device
-  - url: /fhir/r5/Observation?_count=2&patient=40018
+  - url: /FHIR/R5/Observation?_count=2&patient=40018
     json:
       entry:
         - resource:
@@ -257,14 +257,14 @@
                 ZGF0ZV90aW1lIjogIjIwMjYtMDItMTFUMjI6Mzk6MDkrMDA6MDAifX0=
       link:
         - relation: self
-          url: https://jhe.local/fhir/r5/Observation?_count=2&patient=40018
+          url: https://jhe.local/FHIR/R5/Observation?_count=2&patient=40018
         - relation: next
-          url: https://jhe.local/fhir/r5/Observation?_count=2&_page=2&patient=40018
+          url: https://jhe.local/FHIR/R5/Observation?_count=2&_page=2&patient=40018
       meta: {}
       resourceType: Bundle
       total: 3
       type: searchset
-  - url: /fhir/r5/Observation?_count=2&patient=40018&_page=2
+  - url: /FHIR/R5/Observation?_count=2&patient=40018&_page=2
     json:
       entry:
         - resource:
@@ -292,9 +292,9 @@
                 ZGF0ZV90aW1lIjogIjIwMjYtMDItMTFUMjI6Mzk6MDkrMDA6MDAifX0=
       link:
         - relation: self
-          url: https://jhe.local/fhir/r5/Observation?_count=2&patient=40018&_page=2
+          url: https://jhe.local/FHIR/R5/Observation?_count=2&patient=40018&_page=2
         - relation: previous
-          url: https://jhe.local/fhir/r5/Observation?_count=2&patient=40018
+          url: https://jhe.local/FHIR/R5/Observation?_count=2&patient=40018
       meta: {}
       resourceType: Bundle
       total: 3


### PR DESCRIPTION
list_observations failed with 404 because `/fhir/r5` has been changed to `/FHIR/R5` in JHE 0.0.13, breaking all client observation requests